### PR TITLE
Restructure folder layout for data storage and migrate existing data

### DIFF
--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -81,4 +81,21 @@ public interface LootLoggerConfig extends Config
 	)
 	@Range(max = 100)
 	default int itemMissingAlpha() { return 35; }
+
+	@ConfigItem(
+		keyName = "migratedUsers",
+		name = "Migrated users",
+		description = "CSV of usernames (login name) that have been migrated"
+	)
+	default String getMigratedUsers()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "migratedUsers",
+		name = "",
+		description = ""
+	)
+	void setMigratedUsers(String key);
 }

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
@@ -193,14 +193,18 @@ public class LootLoggerPlugin extends Plugin
 
 	private void updateWriterUsername()
 	{
+		final String username = client.getUsername();
+		final boolean alreadyMigrated = Text.fromCSV(config.getMigratedUsers()).stream().anyMatch(username::equalsIgnoreCase);
 		// TODO: Remove this check once the deprecated migrateData call has been remove
-		if (false)
+		if (alreadyMigrated)
 		{
 			writer.setPlayerUsername(client.getUsername());
 			localPlayerNameChanged();
 		}
-
-		migrateData();
+		else
+		{
+			migrateData();
+		}
 	}
 
 	// TODO: Remove in a future release
@@ -221,7 +225,13 @@ public class LootLoggerPlugin extends Plugin
 					final Player local = client.getLocalPlayer();
 					if (local != null && local.getName() != null)
 					{
-						writer.migrateDataFromDisplayNameToUsername(local.getName(), client.getUsername());
+						final boolean migrated = writer.migrateDataFromDisplayNameToUsername(local.getName(), client.getUsername());
+						if (migrated)
+						{
+							final List<String> users = Text.fromCSV(config.getMigratedUsers());
+							users.add(client.getUsername());
+							config.setMigratedUsers(String.join(",", users));
+						}
 						writer.setPlayerUsername(client.getUsername());
 						localPlayerNameChanged();
 						fetchingUsername = false;

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
@@ -192,6 +192,20 @@ public class LootLoggerPlugin extends Plugin
 
 	private void updateWriterUsername()
 	{
+		// TODO: Remove this check once the deprecated migrateData call has been remove
+		if (false)
+		{
+			writer.setPlayerUsername(client.getUsername());
+			localPlayerNameChanged();
+		}
+
+		migrateData();
+	}
+
+	// TODO: Remove in a future release
+	@Deprecated
+	private void migrateData()
+	{
 		if (fetchingUsername)
 		{
 			return;
@@ -206,7 +220,8 @@ public class LootLoggerPlugin extends Plugin
 					final Player local = client.getLocalPlayer();
 					if (local != null && local.getName() != null)
 					{
-						writer.setPlayerUsername(local.getName());
+						writer.migrateDataFromDisplayNameToUsername(local.getName(), client.getUsername());
+						writer.setPlayerUsername(client.getUsername());
 						localPlayerNameChanged();
 						fetchingUsername = false;
 						return true;

--- a/src/main/java/thestonedturtle/lootlogger/data/BossTab.java
+++ b/src/main/java/thestonedturtle/lootlogger/data/BossTab.java
@@ -34,71 +34,73 @@ import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.ItemID;
+import net.runelite.http.api.loottracker.LootRecordType;
 
 @Getter
 @AllArgsConstructor
 public enum BossTab
 {
 	// Chest Rewards
-	BARROWS("Barrows", ItemID.BARROWS_TELEPORT, "Other"),
-	CHAMBERS_OF_XERIC("Chambers of Xeric", ItemID.OLMLET, "Other"),
-	THEATRE_OF_BLOOD("Theatre of Blood", ItemID.LIL_ZIK, "Other"),
+	BARROWS("Barrows", ItemID.BARROWS_TELEPORT, "Other", LootRecordType.EVENT),
+	CHAMBERS_OF_XERIC("Chambers of Xeric", ItemID.OLMLET, "Other", LootRecordType.EVENT),
+	THEATRE_OF_BLOOD("Theatre of Blood", ItemID.LIL_ZIK, "Other", LootRecordType.EVENT),
 
 	// Loot received on NPC death
-	ZULRAH("Zulrah", ItemID.PET_SNAKELING, "Other"),
-	VORKATH("Vorkath", ItemID.VORKI, "Other"),
+	ZULRAH("Zulrah", ItemID.PET_SNAKELING, "Other", LootRecordType.NPC),
+	VORKATH("Vorkath", ItemID.VORKI, "Other", LootRecordType.NPC),
 
 	// God wars dungeon
-	KREEARRA("Kree'arra", ItemID.PET_KREEARRA , "God Wars Dungeon"),
-	GENERAL_GRAARDOR("General Graardor", ItemID.PET_GENERAL_GRAARDOR , "God Wars Dungeon"),
-	COMMANDER_ZILYANA("Commander Zilyana", ItemID.PET_ZILYANA , "God Wars Dungeon"),
-	KRIL_TSUTSAROTH("K'ril Tsutsaroth", ItemID.PET_KRIL_TSUTSAROTH , "God Wars Dungeon"),
+	KREEARRA("Kree'arra", ItemID.PET_KREEARRA , "God Wars Dungeon", LootRecordType.NPC),
+	GENERAL_GRAARDOR("General Graardor", ItemID.PET_GENERAL_GRAARDOR , "God Wars Dungeon", LootRecordType.NPC),
+	COMMANDER_ZILYANA("Commander Zilyana", ItemID.PET_ZILYANA , "God Wars Dungeon", LootRecordType.NPC),
+	KRIL_TSUTSAROTH("K'ril Tsutsaroth", ItemID.PET_KRIL_TSUTSAROTH , "God Wars Dungeon", LootRecordType.NPC),
 
 	// Wildy Bosses
-	VETION("Vet'ion Reborn", ItemID.VETION_JR , "Wilderness"),
-	VENENATIS("Venenatis", ItemID.VENENATIS_SPIDERLING , "Wilderness"),
-	CALLISTO("Callisto", ItemID.CALLISTO_CUB , "Wilderness"),
-	CHAOS_ELEMENTAL("Chaos Elemental", ItemID.PET_CHAOS_ELEMENTAL , "Wilderness"),
+	VETION("Vet'ion Reborn", ItemID.VETION_JR , "Wilderness", LootRecordType.NPC),
+	VENENATIS("Venenatis", ItemID.VENENATIS_SPIDERLING , "Wilderness", LootRecordType.NPC),
+	CALLISTO("Callisto", ItemID.CALLISTO_CUB , "Wilderness", LootRecordType.NPC),
+	CHAOS_ELEMENTAL("Chaos Elemental", ItemID.PET_CHAOS_ELEMENTAL , "Wilderness", LootRecordType.NPC),
 	// Wildy Demi-Bosses
-	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING, "Wilderness"),
-	CHAOS_FANATIC("Chaos Fanatic", ItemID.ANCIENT_STAFF , "Wilderness"),
-	CRAZY_ARCHAEOLOGIST("Crazy Archaeologist", ItemID.FEDORA , "Wilderness"),
+	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING, "Wilderness", LootRecordType.NPC),
+	CHAOS_FANATIC("Chaos Fanatic", ItemID.ANCIENT_STAFF , "Wilderness", LootRecordType.NPC),
+	CRAZY_ARCHAEOLOGIST("Crazy Archaeologist", ItemID.FEDORA , "Wilderness", LootRecordType.NPC),
 	// Wildy Other
-	KING_BLACK_DRAGON("King Black Dragon", ItemID.PRINCE_BLACK_DRAGON , "Wilderness"),
+	KING_BLACK_DRAGON("King Black Dragon", ItemID.PRINCE_BLACK_DRAGON , "Wilderness", LootRecordType.NPC),
 
 	// Slayer Bosses
-	KALPHITE_QUEEN("Kalphite Queen", ItemID.KALPHITE_PRINCESS, "Other"),
-	SKOTIZO("Skotizo", ItemID.SKOTOS, "Slayer"),
-	GROTESQUE_GUARDIANS("Dusk", ItemID.NOON, "Slayer"),
-	ABYSSAL_SIRE("Abyssal Sire", ItemID.ABYSSAL_ORPHAN, "Slayer"),
-	KRAKEN("Kraken", ItemID.PET_KRAKEN, "Slayer"),
-	CERBERUS("Cerberus", ItemID.HELLPUPPY, "Slayer"),
-	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear smoke devil", ItemID.PET_SMOKE_DEVIL, "Slayer"),
-	ALCHEMICAL_HYDRA("Alchemical Hydra", ItemID.IKKLE_HYDRA, "Slayer"),
+	KALPHITE_QUEEN("Kalphite Queen", ItemID.KALPHITE_PRINCESS, "Other", LootRecordType.NPC),
+	SKOTIZO("Skotizo", ItemID.SKOTOS, "Slayer", LootRecordType.NPC),
+	GROTESQUE_GUARDIANS("Dusk", ItemID.NOON, "Slayer", LootRecordType.NPC),
+	ABYSSAL_SIRE("Abyssal Sire", ItemID.ABYSSAL_ORPHAN, "Slayer", LootRecordType.NPC),
+	KRAKEN("Kraken", ItemID.PET_KRAKEN, "Slayer", LootRecordType.NPC),
+	CERBERUS("Cerberus", ItemID.HELLPUPPY, "Slayer", LootRecordType.NPC),
+	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear smoke devil", ItemID.PET_SMOKE_DEVIL, "Slayer", LootRecordType.NPC),
+	ALCHEMICAL_HYDRA("Alchemical Hydra", ItemID.IKKLE_HYDRA, "Slayer", LootRecordType.NPC),
 
 	// Other Bosses
-	GIANT_MOLE("Giant Mole", ItemID.BABY_MOLE, "Other"),
-	CORPOREAL_BEAST("Corporeal Beast", ItemID.PET_CORPOREAL_CRITTER, "Other"),
-	THE_GAUNTLET("The Gauntlet", ItemID.YOUNGLLEF, "Other"),
-	ZALCANO("Zalcano", ItemID.SMOLCANO, "Other"),
-	NIGHTMARE("The Nightmare", ItemID.LITTLE_NIGHTMARE, "Other"),
+	GIANT_MOLE("Giant Mole", ItemID.BABY_MOLE, "Other", LootRecordType.NPC),
+	CORPOREAL_BEAST("Corporeal Beast", ItemID.PET_CORPOREAL_CRITTER, "Other", LootRecordType.NPC),
+	THE_GAUNTLET("The Gauntlet", ItemID.YOUNGLLEF, "Other", LootRecordType.EVENT),
+	ZALCANO("Zalcano", ItemID.SMOLCANO, "Other", LootRecordType.NPC),
+	NIGHTMARE("The Nightmare", ItemID.LITTLE_NIGHTMARE, "Other", LootRecordType.NPC),
 
 	// Dagannoth Kings
-	DAGANNOTH_REX("Dagannoth Rex", ItemID.PET_DAGANNOTH_REX, "Dagannoth Kings"),
-	DAGANNOTH_PRIME("Dagannoth Prime", ItemID.PET_DAGANNOTH_PRIME, "Dagannoth Kings"),
-	DAGANNOTH_SUPREME("Dagannoth Supreme", ItemID.PET_DAGANNOTH_SUPREME, "Dagannoth Kings"),
+	DAGANNOTH_REX("Dagannoth Rex", ItemID.PET_DAGANNOTH_REX, "Dagannoth Kings", LootRecordType.NPC),
+	DAGANNOTH_PRIME("Dagannoth Prime", ItemID.PET_DAGANNOTH_PRIME, "Dagannoth Kings", LootRecordType.NPC),
+	DAGANNOTH_SUPREME("Dagannoth Supreme", ItemID.PET_DAGANNOTH_SUPREME, "Dagannoth Kings", LootRecordType.NPC),
 
 	// Clue scrolls
-	CLUE_SCROLL_BEGINNER("Clue Scroll (Beginner)", ItemID.CLUE_SCROLL_BEGINNER, "Clue Scrolls"),
-	CLUE_SCROLL_EASY("Clue Scroll (Easy)", ItemID.CLUE_SCROLL_EASY, "Clue Scrolls"),
-	CLUE_SCROLL_MEDIUM("Clue Scroll (Medium)", ItemID.CLUE_SCROLL_MEDIUM, "Clue Scrolls"),
-	CLUE_SCROLL_HARD("Clue Scroll (Hard)", ItemID.CLUE_SCROLL_HARD, "Clue Scrolls"),
-	CLUE_SCROLL_ELITE("Clue Scroll (Elite)", ItemID.CLUE_SCROLL_ELITE, "Clue Scrolls"),
-	CLUE_SCROLL_MASTER("Clue Scroll (Master)", ItemID.CLUE_SCROLL_MASTER, "Clue Scrolls");
+	CLUE_SCROLL_BEGINNER("Clue Scroll (Beginner)", ItemID.CLUE_SCROLL_BEGINNER, "Clue Scrolls", LootRecordType.EVENT),
+	CLUE_SCROLL_EASY("Clue Scroll (Easy)", ItemID.CLUE_SCROLL_EASY, "Clue Scrolls", LootRecordType.EVENT),
+	CLUE_SCROLL_MEDIUM("Clue Scroll (Medium)", ItemID.CLUE_SCROLL_MEDIUM, "Clue Scrolls", LootRecordType.EVENT),
+	CLUE_SCROLL_HARD("Clue Scroll (Hard)", ItemID.CLUE_SCROLL_HARD, "Clue Scrolls", LootRecordType.EVENT),
+	CLUE_SCROLL_ELITE("Clue Scroll (Elite)", ItemID.CLUE_SCROLL_ELITE, "Clue Scrolls", LootRecordType.EVENT),
+	CLUE_SCROLL_MASTER("Clue Scroll (Master)", ItemID.CLUE_SCROLL_MASTER, "Clue Scrolls", LootRecordType.EVENT);
 
 	private final String name;
 	private final int itemID;
 	private final String category;
+	private final LootRecordType type;
 
 	private static final Map<String, BossTab> NAME_MAP;
 	private static final Multimap<String, BossTab> CATEGORY_MAP;

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
@@ -24,6 +24,9 @@
  */
 package thestonedturtle.lootlogger.localstorage;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -33,13 +36,16 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import static net.runelite.client.RuneLite.RUNELITE_DIR;
 import net.runelite.http.api.RuneLiteAPI;
+import net.runelite.http.api.loottracker.LootRecordType;
 
 /**
  * Reads & Writes LootRecord data from `*name*.log` files located in `.runelite/loots/`.
@@ -54,6 +60,8 @@ public class LootRecordWriter
 
 	// Data is stored in a folder with the players username (login name)
 	private File playerFolder = LOOT_RECORD_DIR;
+	// Data is separated into sub-folders by event type to prevent issues.
+	private final Map<LootRecordType, File> eventFolders = new HashMap<>();
 	private String name;
 
 	@Inject
@@ -72,6 +80,18 @@ public class LootRecordWriter
 		playerFolder = new File(LOOT_RECORD_DIR, username);
 		playerFolder.mkdir();
 		name = username;
+		createSubFolders();
+	}
+
+	private void createSubFolders()
+	{
+		eventFolders.clear();
+		for (final LootRecordType type : LootRecordType.values())
+		{
+			final File folder = new File(playerFolder, type.name().toLowerCase());
+			folder.mkdir();
+			eventFolders.put(type, folder);
+		}
 	}
 
 	private static String npcNameToFileName(final String npcName)
@@ -97,8 +117,15 @@ public class LootRecordWriter
 
 	public synchronized Collection<LTRecord> loadLootTrackerRecords(String npcName)
 	{
+		return loadLootTrackerRecords(npcName, playerFolder);
+	}
+
+	// TODO: Remove folder parameter in future release when data migration is no longer needed
+	@Deprecated
+	public synchronized Collection<LTRecord> loadLootTrackerRecords(String npcName, File folder)
+	{
 		final String fileName = npcNameToFileName(npcName);
-		final File file = new File(playerFolder, fileName);
+		final File file = new File(folder, fileName);
 		final Collection<LTRecord> data = new ArrayList<>();
 
 		try (final BufferedReader br = new BufferedReader(new FileReader(file)))
@@ -199,6 +226,8 @@ public class LootRecordWriter
 		}
 	}
 
+	// TODO: Remove this in a future release
+	@Deprecated
 	public boolean migrateDataFromDisplayNameToUsername(final String displayName, final String username)
 	{
 		final File currentDirectory = new File(LOOT_RECORD_DIR, displayName);
@@ -210,9 +239,85 @@ public class LootRecordWriter
 
 		if (displayName.equalsIgnoreCase(username))
 		{
+			return migrateDataLayout(currentDirectory);
+		}
+
+		final File newDirectory = new File(LOOT_RECORD_DIR, username);
+		final boolean renamed = currentDirectory.renameTo(newDirectory);
+		if (!renamed)
+		{
 			return false;
 		}
 
-		return currentDirectory.renameTo(new File(LOOT_RECORD_DIR, username));
+		return migrateDataLayout(newDirectory);
+	}
+
+	// TODO: Remove this in a future release
+	@Deprecated
+	public boolean migrateDataLayout(final File folder)
+	{
+		final File[] files = folder.listFiles((dir, name) -> name.endsWith(FILE_EXTENSION));
+		if (files == null)
+		{
+			return false;
+		}
+
+		if (files.length == 0)
+		{
+			// Assume data is already migrated to the new format if there are no loot files inside the directory
+			return true;
+		}
+
+		for (final File f : files)
+		{
+			final String filename = f.getName().replace(FILE_EXTENSION, "");
+
+			// Load current data and sort by LootRecordType to fix any existing name conflicts
+			final Collection<LTRecord> records = loadLootTrackerRecords(filename, folder);
+			final Multimap<LootRecordType, LTRecord> filtered = records.stream()
+				.collect(Multimaps.toMultimap(
+					LTRecord::getType,
+					(rec) -> rec,
+					ArrayListMultimap::create)
+				);
+
+			final Set<LootRecordType> keys = filtered.keySet();
+			for (final LootRecordType key : keys)
+			{
+				final File outputDir = new File(folder, key.name().toLowerCase());
+				outputDir.mkdir();
+
+				final File outputFile = new File(outputDir, f.getName());
+				// If there's only 1 key we can just move the existing file instead unmarshalling the data again
+				if (keys.size() == 1)
+				{
+					f.renameTo(outputFile);
+				}
+				else
+				{
+					final Collection<LTRecord> recs = filtered.get(key);
+					try
+					{
+						final BufferedWriter file = new BufferedWriter(new FileWriter(String.valueOf(outputFile), false));
+						for (final LTRecord rec : recs)
+						{
+							// Convert entry to JSON
+							final String dataAsString = RuneLiteAPI.GSON.toJson(rec);
+							file.append(dataAsString);
+							file.newLine();
+						}
+						file.close();
+					}
+					catch (IOException ioe)
+					{
+						log.warn("Error migrating loot data from file `{}` to `{}`", f.getPath(), outputFile.getPath());
+						continue;
+					}
+					f.delete();
+				}
+			}
+		}
+
+		return true;
 	}
 }

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
@@ -52,7 +52,7 @@ public class LootRecordWriter
 	private static final String FILE_EXTENSION = ".log";
 	private static final File LOOT_RECORD_DIR = new File(RUNELITE_DIR, "loots");
 
-	// Data is stored in a folder with the players in-game username
+	// Data is stored in a folder with the players username (login name)
 	private File playerFolder = LOOT_RECORD_DIR;
 	private String name;
 
@@ -197,5 +197,22 @@ public class LootRecordWriter
 			log.warn("Error rewriting loot data to file {}: {}", fileName, ioe.getMessage());
 			return false;
 		}
+	}
+
+	public boolean migrateDataFromDisplayNameToUsername(final String displayName, final String username)
+	{
+		final File currentDirectory = new File(LOOT_RECORD_DIR, displayName);
+		if (!currentDirectory.exists())
+		{
+			// Most likely was already converted
+			return false;
+		}
+
+		if (displayName.equalsIgnoreCase(username))
+		{
+			return false;
+		}
+
+		return currentDirectory.renameTo(new File(LOOT_RECORD_DIR, username));
 	}
 }

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootLoggerPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootLoggerPanel.java
@@ -47,6 +47,7 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.PluginErrorPanel;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.http.api.loottracker.LootRecordType;
 import thestonedturtle.lootlogger.LootLoggerPlugin;
 import thestonedturtle.lootlogger.data.LootLog;
 import thestonedturtle.lootlogger.localstorage.LTRecord;
@@ -95,7 +96,7 @@ public class LootLoggerPanel extends PluginPanel
 		showLootView();
 	}
 
-	public void requestLootLog(final String name)
+	public void requestLootLog(final LootRecordType type, final String name)
 	{
 		// For some reason removing all the components when there's a lot of names in the selectionPanel causes lag.
 		// Removing them here seems to mitigate the lag
@@ -104,7 +105,7 @@ public class LootLoggerPanel extends PluginPanel
 			selectionPanel.getNamePanel().removeAll();
 		}
 
-		plugin.requestLootLog(name);
+		plugin.requestLootLog(type, name);
 	}
 
 	// Loot Selection view
@@ -186,7 +187,7 @@ public class LootLoggerPanel extends PluginPanel
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
-				requestLootLog(name);
+				requestLootLog(lootLog.getType(), name);
 			}
 		});
 		refresh.setToolTipText("Refresh panel");
@@ -198,7 +199,7 @@ public class LootLoggerPanel extends PluginPanel
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
-				clearData(name);
+				clearData(lootLog.getType(), name);
 			}
 		});
 		clear.setToolTipText("Clear stored data");
@@ -266,13 +267,13 @@ public class LootLoggerPanel extends PluginPanel
 	}
 
 	// Clear stored data and return to selection screen
-	private void clearData(final String name)
+	private void clearData(final LootRecordType type, final String name)
 	{
 		// Confirm delete action
 		final int delete = JOptionPane.showConfirmDialog(this.getRootPane(), "<html>Are you sure you want to clear all data for this tab?<br/>There is no way to undo this action.</html>", "Warning", JOptionPane.YES_NO_OPTION);
 		if (delete == JOptionPane.YES_OPTION)
 		{
-			boolean deleted = plugin.clearStoredDataByName(name);
+			boolean deleted = plugin.clearStoredDataByName(type, name);
 			if (!deleted)
 			{
 				JOptionPane.showMessageDialog(this.getRootPane(), "Unable to clear stored data, please try again.");
@@ -288,7 +289,7 @@ public class LootLoggerPanel extends PluginPanel
 	{
 		if (lootLog == null)
 		{
-			requestLootLog(r.getName());
+			requestLootLog(r.getType(), r.getName());
 		}
 		else if (lootLog.getName().equalsIgnoreCase(r.getName()))
 		{


### PR DESCRIPTION
Closes #10 

The plugin will automatically try to migrate data to the new format when logging in. This logic should be removed in a future release once enough time has passed for a majority of the users to have triggered the automatic migration.

The folder structure for storing data inside `~/.runelite/loots` has been updated as follows:

1) Changed folder `name` to use login username and not in-game display name. This will fix data loss/migration issues when changing names.
2) Separated record into their own folders by LootRecordType. This will fix issues where names collide for different record types, such as an NPC that can be killed and pick-pocketed.

Example Directory Tree
```
.runelite/
....
├── logs/
├── loots/
├   ├── *name*/
├      ├── event/
├      ├── npc/
├      ├── pickpocket/
├      ├── player/
├      └── unknown/
├── plugins/
....
```