### PR TITLE
Historic total prices

### DIFF
--- a/src/main/java/thestonedturtle/lootlogger/ItemSortTypes.java
+++ b/src/main/java/thestonedturtle/lootlogger/ItemSortTypes.java
@@ -9,8 +9,8 @@ public enum ItemSortTypes
 {
 	ALPHABETICAL("Alphabetical"),
 	ITEM_ID("Item ID"),
-	TOTAL_VALUE("Total value"),
-	INDIVIDUAL_VALUE("Individual value");
+	VALUE("Stack value"),
+	PRICE("Single value");
 
 	private final String name;
 

--- a/src/main/java/thestonedturtle/lootlogger/ItemSortTypes.java
+++ b/src/main/java/thestonedturtle/lootlogger/ItemSortTypes.java
@@ -9,8 +9,8 @@ public enum ItemSortTypes
 {
 	ALPHABETICAL("Alphabetical"),
 	ITEM_ID("Item ID"),
-	VALUE("Value"),
-	PRICE("Price");
+	TOTAL_VALUE("Total value"),
+	INDIVIDUAL_VALUE("Individual value");
 
 	private final String name;
 

--- a/src/main/java/thestonedturtle/lootlogger/ItemValueTypes.java
+++ b/src/main/java/thestonedturtle/lootlogger/ItemValueTypes.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ItemValueTypes
 {
-    GRAND_EXCHANGE("Grand Exchange"),
+    GRAND_EXCHANGE_LATEST("Grand Exchange (Latest)"),
+    GRAND_EXCHANGE_HISTORIC("Grand Exchange (Historic)"),
     HIGH_ALCHEMY("High Alchemy");
 
     private final String name;

--- a/src/main/java/thestonedturtle/lootlogger/ItemValueTypes.java
+++ b/src/main/java/thestonedturtle/lootlogger/ItemValueTypes.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ItemValueTypes
 {
-    GRAND_EXCHANGE_LATEST("Grand Exchange (Latest)"),
-    GRAND_EXCHANGE_HISTORIC("Grand Exchange (Historic)"),
+    GRAND_EXCHANGE("Grand Exchange"),
+    GRAND_EXCHANGE_AVERAGED("Averaged"),
     HIGH_ALCHEMY("High Alchemy");
 
     private final String name;

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -46,7 +46,7 @@ public interface LootLoggerConfig extends Config
 	)
 	default ItemSortTypes itemSortType()
 	{
-		return ItemSortTypes.TOTAL_VALUE;
+		return ItemSortTypes.VALUE;
 	}
 
 	@ConfigItem(

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -46,7 +46,7 @@ public interface LootLoggerConfig extends Config
 	)
 	default ItemSortTypes itemSortType()
 	{
-		return ItemSortTypes.VALUE;
+		return ItemSortTypes.TOTAL_VALUE;
 	}
 
 	@ConfigItem(

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -122,7 +122,11 @@ public interface LootLoggerConfig extends Config
 		position = 1,
 		keyName = "itemValue",
 		name = "Item Value",
-		description = "Which value to use when calculating item prices<br>Grand Exchange (Latest): calculate totals using GE price at time of latest drop<br>Grand Exchange (Historic): calculate totals using GE price at the time of each drop, with individual price being the average"
+		description = "Which value to use when calculating item prices"
+					+ "<br>"
+					+ "<br><b>Grand Exchange:</b> Calculate totals using the GE price at time of the latest drop"
+					+ "<br><b>Averaged:</b> Calculate totals by summing the GE prices at the time of each drop"
+					+ "<br><b>High Alchemy:</b> Calculate totals using the High Alchemy value"
 	)
-	default ItemValueTypes valueType() {return ItemValueTypes.GRAND_EXCHANGE_LATEST;}
+	default ItemValueTypes valueType() {return ItemValueTypes.GRAND_EXCHANGE;}
 }

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -122,7 +122,7 @@ public interface LootLoggerConfig extends Config
 		position = 1,
 		keyName = "itemValue",
 		name = "Item Value",
-		description = "Which value to use when calculating item prices"
+		description = "Which value to use when calculating item prices<br>Grand Exchange (Latest): calculate totals using GE price at time of latest drop<br>Grand Exchange (Historic): calculate totals using GE price at the time of each drop"
 	)
-	default ItemValueTypes valueType() {return ItemValueTypes.GRAND_EXCHANGE;}
+	default ItemValueTypes valueType() {return ItemValueTypes.GRAND_EXCHANGE_LATEST;}
 }

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerConfig.java
@@ -122,7 +122,7 @@ public interface LootLoggerConfig extends Config
 		position = 1,
 		keyName = "itemValue",
 		name = "Item Value",
-		description = "Which value to use when calculating item prices<br>Grand Exchange (Latest): calculate totals using GE price at time of latest drop<br>Grand Exchange (Historic): calculate totals using GE price at the time of each drop"
+		description = "Which value to use when calculating item prices<br>Grand Exchange (Latest): calculate totals using GE price at time of latest drop<br>Grand Exchange (Historic): calculate totals using GE price at the time of each drop, with individual price being the average"
 	)
 	default ItemValueTypes valueType() {return ItemValueTypes.GRAND_EXCHANGE_LATEST;}
 }

--- a/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
+++ b/src/main/java/thestonedturtle/lootlogger/LootLoggerPlugin.java
@@ -276,7 +276,8 @@ public class LootLoggerPlugin extends Plugin
 		final ItemComposition c = itemManager.getItemComposition(id);
 		final int realId = c.getNote() == -1 ? c.getId() : c.getLinkedNoteId();
 		final int price = itemManager.getItemPrice(realId);
-		return new LTItemEntry(c.getName(), id, qty, price, c.getHaPrice());
+		final long totalPrice = (long) price * qty;
+		return new LTItemEntry(c.getName(), id, qty, price, c.getHaPrice(), totalPrice);
 	}
 
 	private void addRecord(final LTRecord record)
@@ -495,7 +496,7 @@ public class LootLoggerPlugin extends Plugin
 		{
 			Collection<LTRecord> data = getDataByName(LootRecordType.NPC, BossTab.ABYSSAL_SIRE.getName());
 			ItemComposition c = itemManager.getItemComposition(itemID);
-			LTItemEntry itemEntry = new LTItemEntry(c.getName(), itemID, 1, 0, c.getHaPrice());
+			LTItemEntry itemEntry = new LTItemEntry(c.getName(), itemID, 1, 0, c.getHaPrice(), 0);
 
 			log.debug("Received Unsired item: {}", c.getName());
 

--- a/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
+++ b/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
@@ -160,7 +160,7 @@ public class LootLog
 			// Use the most recent price
 			oldEntry.setPrice(item.getPrice());
 			oldEntry.setQuantity(oldEntry.getQuantity() + item.getQuantity());
-			oldEntry.setHistoricTotalPrice(oldEntry.historicTotalPrice + item.getHistoricTotalPrice());
+			oldEntry.setAveragedTotalPrice(oldEntry.averagedTotalPrice + item.getAveragedTotalPrice());
 		}
 		else
 		{

--- a/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
+++ b/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
@@ -43,7 +43,6 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.http.api.loottracker.LootRecordType;
-import thestonedturtle.lootlogger.ItemValueTypes;
 import thestonedturtle.lootlogger.LootLoggerConfig;
 import thestonedturtle.lootlogger.localstorage.LTItemEntry;
 import thestonedturtle.lootlogger.localstorage.LTRecord;
@@ -94,12 +93,6 @@ public class LootLog
 		}
 
 		final Collection<UniqueItem> unsorted = UniqueItem.getUniquesForBoss(name);
-		if (unsorted == null)
-		{
-			uniques = new ArrayList<>();
-			return;
-		}
-
 		uniques = unsorted.stream().sorted(Comparator.comparingInt(UniqueItem::getPosition)).collect(Collectors.toList());
 	}
 
@@ -122,17 +115,17 @@ public class LootLog
 	{
 		final String itemNameLowercased = item.getName().toLowerCase();
 
-		ClueType type = null;
+		ClueType clueType = null;
 		if (itemNameLowercased.startsWith("clue scroll"))
 		{
-			type = ClueType.SCROLL;
+			clueType = ClueType.SCROLL;
 		}
 		else if(itemNameLowercased.startsWith("casket "))
 		{
-			type = ClueType.CASKET;
+			clueType = ClueType.CASKET;
 		}
 
-		if (type != null)
+		if (clueType != null)
 		{
 			Matcher m = CLUE_ITEM_TYPE_PATTERN.matcher(item.getName());
 			if (m.find())
@@ -143,20 +136,20 @@ public class LootLog
 				{
 					// Beginner and Master clues only have 1 ID
 					case "easy":
-						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_EASY_SIMPLE001 : ItemID.TRAIL_CLUE_EASY_MAP001_CASKET;
+						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_EASY_SIMPLE001 : ItemID.TRAIL_CLUE_EASY_MAP001_CASKET;
 						break;
 					case "medium":
-						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001 : ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001_CASKET;
+						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001 : ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001_CASKET;
 						break;
 					case "hard":
-						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_HARD_MAP001 : ItemID.TRAIL_CLUE_HARD_SEXTANT001_CASKET;
+						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_HARD_MAP001 : ItemID.TRAIL_CLUE_HARD_SEXTANT001_CASKET;
 						break;
 					case "elite":
-						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_ELITE_EMOTE_EXP1 : ItemID.TRAIL_ELITE_EMOTE_CASKET;
+						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_ELITE_EMOTE_EXP1 : ItemID.TRAIL_ELITE_EMOTE_CASKET;
 						break;
 				}
 
-				item = new LTItemEntry(item.getName(), id, item.getQuantity(), item.getPrice(), item.getHaPrice());
+				item = new LTItemEntry(item.getName(), id, item.getQuantity(), item.getPrice(), item.getHaPrice(), item.getQuantity() * item.getPrice());
 			}
 		}
 
@@ -166,11 +159,12 @@ public class LootLog
 			// Use the most recent price
 			oldEntry.setPrice(item.getPrice());
 			oldEntry.setQuantity(oldEntry.getQuantity() + item.getQuantity());
+			oldEntry.setHistoricTotalPrice(oldEntry.historicTotalPrice + item.getHistoricTotalPrice());
 		}
 		else
 		{
 			// Create a new instance for consolidated records
-			consolidated.put(item.getId(), new LTItemEntry(item.getName(), item.getId(), item.getQuantity(), item.getPrice(), item.getHaPrice()));
+			consolidated.put(item.getId(), new LTItemEntry(item.getName(), item.getId(), item.getQuantity(), item.getPrice(), item.getHaPrice(), item.getQuantity() * item.getPrice()));
 		}
 	}
 

--- a/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
+++ b/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
@@ -43,6 +43,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.http.api.loottracker.LootRecordType;
+import thestonedturtle.lootlogger.ItemValueTypes;
 import thestonedturtle.lootlogger.LootLoggerConfig;
 import thestonedturtle.lootlogger.localstorage.LTItemEntry;
 import thestonedturtle.lootlogger.localstorage.LTRecord;
@@ -182,11 +183,11 @@ public class LootLog
 		return null;
 	}
 
-	public long getLootValue(boolean includeMinions)
+	public long getLootValue(boolean includeMinions, ItemValueTypes valueType)
 	{
 		long value = getConsolidated()
 			.values().stream()
-			.mapToLong(e -> e.getTotalByType(config.valueType()))
+			.mapToLong(e -> e.getTotalByType(valueType))
 			.sum();
 
 		if (includeMinions)
@@ -195,12 +196,27 @@ public class LootLog
 			{
 				value += minionLog.getConsolidated()
 					.values().stream()
-					.mapToLong(e -> e.getTotalByType(config.valueType()))
+					.mapToLong(e -> e.getTotalByType(valueType))
 					.sum();
 			}
 		}
 
 		return value;
+	}
+
+	public long getLootValue(boolean includeMinions)
+	{
+		return getLootValue(includeMinions, config.valueType());
+	}
+
+	public long getLootValue(ItemValueTypes valueType)
+	{
+		return getLootValue(config.includeMinions(), valueType);
+	}
+
+	public long getLootValue()
+	{
+		return getLootValue(config.includeMinions(), config.valueType());
 	}
 
 	// Loop over all UniqueItems and check how many the player has received as a drop for each

--- a/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
+++ b/src/main/java/thestonedturtle/lootlogger/data/LootLog.java
@@ -116,17 +116,17 @@ public class LootLog
 	{
 		final String itemNameLowercased = item.getName().toLowerCase();
 
-		ClueType clueType = null;
+		ClueType type = null;
 		if (itemNameLowercased.startsWith("clue scroll"))
 		{
-			clueType = ClueType.SCROLL;
+			type = ClueType.SCROLL;
 		}
 		else if(itemNameLowercased.startsWith("casket "))
 		{
-			clueType = ClueType.CASKET;
+			type = ClueType.CASKET;
 		}
 
-		if (clueType != null)
+		if (type != null)
 		{
 			Matcher m = CLUE_ITEM_TYPE_PATTERN.matcher(item.getName());
 			if (m.find())
@@ -137,16 +137,16 @@ public class LootLog
 				{
 					// Beginner and Master clues only have 1 ID
 					case "easy":
-						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_EASY_SIMPLE001 : ItemID.TRAIL_CLUE_EASY_MAP001_CASKET;
+						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_EASY_SIMPLE001 : ItemID.TRAIL_CLUE_EASY_MAP001_CASKET;
 						break;
 					case "medium":
-						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001 : ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001_CASKET;
+						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001 : ItemID.TRAIL_CLUE_MEDIUM_SEXTANT001_CASKET;
 						break;
 					case "hard":
-						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_HARD_MAP001 : ItemID.TRAIL_CLUE_HARD_SEXTANT001_CASKET;
+						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_CLUE_HARD_MAP001 : ItemID.TRAIL_CLUE_HARD_SEXTANT001_CASKET;
 						break;
 					case "elite":
-						id = clueType.equals(ClueType.SCROLL) ? ItemID.TRAIL_ELITE_EMOTE_EXP1 : ItemID.TRAIL_ELITE_EMOTE_CASKET;
+						id = type.equals(ClueType.SCROLL) ? ItemID.TRAIL_ELITE_EMOTE_EXP1 : ItemID.TRAIL_ELITE_EMOTE_CASKET;
 						break;
 				}
 

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
@@ -39,15 +39,15 @@ public class LTItemEntry {
 	// Rather than serializing HA price and change the output format at all, mark transient and fetch it on deserialisation.
 	public final transient int haPrice;
 	// Transient for record format compatibility due to being cheap to construct at runtime anyway.
-	public transient long historicTotalPrice;
+	public transient long averagedTotalPrice;
 
 	public long getPriceByType(ItemValueTypes valueType)
 	{
 		switch (valueType) {
 			case HIGH_ALCHEMY:
 				return haPrice;
-			case GRAND_EXCHANGE_HISTORIC:
-				return historicTotalPrice / quantity;
+			case GRAND_EXCHANGE_AVERAGED:
+				return averagedTotalPrice / quantity;
 			default:
 				return price;
 		}
@@ -55,6 +55,6 @@ public class LTItemEntry {
 
 	public long getTotalByType(ItemValueTypes valueType)
 	{
-		return valueType == ItemValueTypes.GRAND_EXCHANGE_HISTORIC ? this.historicTotalPrice : this.quantity * this.getPriceByType(valueType);
+		return valueType == ItemValueTypes.GRAND_EXCHANGE_AVERAGED ? this.averagedTotalPrice : this.quantity * this.getPriceByType(valueType);
 	}
 }

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
@@ -43,7 +43,14 @@ public class LTItemEntry {
 
 	public long getPriceByType(ItemValueTypes valueType)
 	{
-		return valueType == ItemValueTypes.HIGH_ALCHEMY ? (long) this.haPrice : this.price;
+		switch (valueType) {
+			case HIGH_ALCHEMY:
+				return haPrice;
+			case GRAND_EXCHANGE_HISTORIC:
+				return historicTotalPrice / quantity;
+			default:
+				return price;
+		}
 	}
 
 	public long getTotalByType(ItemValueTypes valueType)

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
@@ -37,6 +37,8 @@ public class LTItemEntry {
 	public long price;
 	// Rather than serializing HA price and change the output format at all, mark transient and fetch it on deserialisation.
 	public final transient int haPrice;
+	// Transient for record format compatibility due to being cheap to construct at runtime anyway.
+	public transient long historicTotalPrice;
 
 	public long getPriceByType(ItemValueTypes valueType)
 	{

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LTItemEntry.java
@@ -34,6 +34,7 @@ public class LTItemEntry {
 	public final String name;
 	public final int id;
 	public int quantity;
+	// Price of item at most recent drop
 	public long price;
 	// Rather than serializing HA price and change the output format at all, mark transient and fetch it on deserialisation.
 	public final transient int haPrice;
@@ -42,11 +43,11 @@ public class LTItemEntry {
 
 	public long getPriceByType(ItemValueTypes valueType)
 	{
-		return valueType == ItemValueTypes.GRAND_EXCHANGE ? this.price : (long) this.haPrice;
+		return valueType == ItemValueTypes.HIGH_ALCHEMY ? (long) this.haPrice : this.price;
 	}
 
 	public long getTotalByType(ItemValueTypes valueType)
 	{
-		return this.quantity * this.getPriceByType(valueType);
+		return valueType == ItemValueTypes.GRAND_EXCHANGE_HISTORIC ? this.historicTotalPrice : this.quantity * this.getPriceByType(valueType);
 	}
 }

--- a/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
+++ b/src/main/java/thestonedturtle/lootlogger/localstorage/LootRecordWriter.java
@@ -94,7 +94,8 @@ public class LootRecordWriter
 			int quantity = jsonObject.get("quantity").getAsInt();
 			long price = jsonObject.get("price").getAsLong();
 			int haPrice = haPrices.getOrDefault(id, 0);
-			return new LTItemEntry(name, id, quantity, price, haPrice);
+			long totalPrice = price * quantity;
+			return new LTItemEntry(name, id, quantity, price, haPrice, totalPrice);
 		}
 	}
 

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootGrid.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootGrid.java
@@ -92,16 +92,16 @@ class LootGrid extends JPanel
 	{
 		final String name = item.getName();
 		final int quantity = item.getQuantity();
-		final long latestPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE_LATEST);
+		final long latestPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE);
 		final long haPrice = item.getPriceByType(ItemValueTypes.HIGH_ALCHEMY);
-		final long avgPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
-		final long historicTotal = item.getTotalByType(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
+		final long avgPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE_AVERAGED);
+		final long averagedTotal = item.getTotalByType(ItemValueTypes.GRAND_EXCHANGE_AVERAGED);
 
 		return "<html>" + name + " x " + QuantityFormatter.formatNumber(quantity)
 			+ "<br/>Price (Latest): " + QuantityFormatter.quantityToStackSize(latestPrice)
 			+ "<br/>Total (Latest): " + QuantityFormatter.quantityToStackSize(quantity * latestPrice)
-			+ "<br/>Price (Average): " + QuantityFormatter.quantityToStackSize(avgPrice)
-			+ "<br/>Total (Historic): " + QuantityFormatter.quantityToStackSize(historicTotal)
+			+ "<br/>Price (Averaged): " + QuantityFormatter.quantityToStackSize(avgPrice)
+			+ "<br/>Total (Averaged): " + QuantityFormatter.quantityToStackSize(averagedTotal)
 			+ "<br/>Price (HA): " + QuantityFormatter.quantityToStackSize(haPrice)
 			+ "<br/>Total (HA): " + QuantityFormatter.quantityToStackSize(quantity * haPrice) + "</html>";
 	}

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootGrid.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootGrid.java
@@ -32,6 +32,7 @@ import javax.swing.SwingConstants;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.QuantityFormatter;
+import thestonedturtle.lootlogger.ItemValueTypes;
 import thestonedturtle.lootlogger.localstorage.LTItemEntry;
 
 /**
@@ -91,12 +92,16 @@ class LootGrid extends JPanel
 	{
 		final String name = item.getName();
 		final int quantity = item.getQuantity();
-		final long price = item.getPrice();
-		final long haPrice = item.getHaPrice();
+		final long latestPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE_LATEST);
+		final long haPrice = item.getPriceByType(ItemValueTypes.HIGH_ALCHEMY);
+		final long avgPrice = item.getPriceByType(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
+		final long historicTotal = item.getTotalByType(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
 
 		return "<html>" + name + " x " + QuantityFormatter.formatNumber(quantity)
-			+ "<br/>Price: " + QuantityFormatter.quantityToStackSize(price)
-			+ "<br/>Total: " + QuantityFormatter.quantityToStackSize(quantity * price)
+			+ "<br/>Price (Latest): " + QuantityFormatter.quantityToStackSize(latestPrice)
+			+ "<br/>Total (Latest): " + QuantityFormatter.quantityToStackSize(quantity * latestPrice)
+			+ "<br/>Price (Average): " + QuantityFormatter.quantityToStackSize(avgPrice)
+			+ "<br/>Total (Historic): " + QuantityFormatter.quantityToStackSize(historicTotal)
 			+ "<br/>Price (HA): " + QuantityFormatter.quantityToStackSize(haPrice)
 			+ "<br/>Total (HA): " + QuantityFormatter.quantityToStackSize(quantity * haPrice) + "</html>";
 	}

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -147,18 +147,8 @@ class LootPanel extends JPanel
 		gridBagConstraints.gridy++;
 
 		int killsLogged = lootLog.getRecords().size();
-		if (killsLogged > 0)
-		{
-			killsLoggedPanel.updatePanel(KILLS_LOGGED, killsLogged);
-			killsLoggedPanel.setVisible(true);
-
-			final LTRecord entry = lootLog.getRecords().get(killsLogged - 1);
-			if (entry.getKillCount() != -1)
-			{
-				currentKillcountPanel.updatePanel(CURRENT_KC, entry.getKillCount());
-				currentKillcountPanel.setVisible(true);
-			}
-		}
+		// Get current KC before adding minions
+		final int currentKillcount = killsLogged > 0 ? lootLog.getRecords().get(killsLogged - 1).getKillCount() : -1;
 
 		// Include Main Loot
 		updateMainLootGrid(lootLog);
@@ -186,18 +176,9 @@ class LootPanel extends JPanel
 			}
 		}
 
-		if (totalValue > 0)
-		{
-			updateTotalValuePanel(totalValue);
-			killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
-		}
+		final boolean isCurrentSessionLog = lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME);
 
-		// Change text and include minion kills for session data
-		if (lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME))
-		{
-			killsLoggedPanel.updatePanel(TOTAL_KILLS, killsLogged);
-			killsLoggedPanel.setVisible(killsLogged > 0);
-		}
+		updatePanels(totalValue, killsLogged, currentKillcount, isCurrentSessionLog);
 	}
 
 	private LTItemEntry[] getItemsToDisplay(final LootLog log)
@@ -294,23 +275,16 @@ class LootPanel extends JPanel
 		if (!minionUpdate)
 		{
 			updateMainLootGrid(lootLog);
-
-			// Update KillCount
-			if (lootLog.getRecords().size() > 0)
-			{
-				final LTRecord entry = lootLog.getRecords().get(lootLog.getRecords().size() - 1);
-				currentKillcountPanel.updatePanel(CURRENT_KC, entry.getKillCount());
-				currentKillcountPanel.setVisible(entry.getKillCount() != -1);
-			}
 		}
 
-		// Update Total Value
 		final long totalValue = lootLog.getLootValue();
-		updateTotalValuePanel(totalValue);
 
-		// Update Kills Logged
 		int killsLogged = lootLog.getRecords().size();
-		if (lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME))
+		// Get current KC before adding minion kills
+		final int currentKillcount = killsLogged > 0 ? lootLog.getRecords().get(killsLogged - 1).getKillCount() : -1;
+		final boolean isCurrentSessionLog = lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME);
+
+		if (isCurrentSessionLog)
 		{
 			killsLogged += lootLog.getMinionLogs()
 				.stream()
@@ -318,12 +292,7 @@ class LootPanel extends JPanel
 				.sum();
 		}
 
-		final String killsLoggedText = lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME) ? TOTAL_KILLS : KILLS_LOGGED;
-		killsLoggedPanel.updatePanel(killsLoggedText, killsLogged);
-		killsLoggedPanel.setVisible(killsLogged > 0);
-		if (totalValue > 0) {
-			killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
-		}
+		updatePanels(totalValue, killsLogged, currentKillcount, isCurrentSessionLog);
 	}
 
 	void playback()
@@ -468,6 +437,57 @@ class LootPanel extends JPanel
 		else
 		{
 			totalValuePanel.setVisible(false);
+		}
+	}
+
+	private void updatePanels(long totalValue, int killsLogged, int currentKillcount, boolean isCurrentSessionLog)
+	{
+		if (totalValue > 0)
+		{
+			totalValuePanel.setVisible(true);
+			totalValuePanel.setToolTipText(buildTotalValueTooltip());
+			switch (config.valueType()) {
+				case HIGH_ALCHEMY:
+					totalValuePanel.updatePanel(TOTAL_VALUE_HA, totalValue);
+					break;
+				case GRAND_EXCHANGE_HISTORIC:
+					totalValuePanel.updatePanel(TOTAL_VALUE_HISTORIC, totalValue);
+					break;
+				case GRAND_EXCHANGE_LATEST:
+					totalValuePanel.updatePanel(TOTAL_VALUE_LATEST, totalValue);
+					break;
+				default:
+					totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
+
+			}
+		}
+		else
+		{
+			totalValuePanel.setVisible(false);
+		}
+
+		if (killsLogged > 0)
+		{
+			final String killsLoggedText = isCurrentSessionLog ? TOTAL_KILLS : KILLS_LOGGED;
+			killsLoggedPanel.updatePanel(killsLoggedText, killsLogged);
+			if (totalValue > 0)
+			{
+				killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
+			}
+		}
+		else
+		{
+			killsLoggedPanel.setVisible(false);
+		}
+
+		if (currentKillcount != -1)
+		{
+			currentKillcountPanel.setVisible(true);
+			currentKillcountPanel.updatePanel(CURRENT_KC, currentKillcount);
+		}
+		else
+		{
+			currentKillcountPanel.setVisible(false);
 		}
 	}
 

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -59,6 +59,9 @@ class LootPanel extends JPanel
 	private static final String CURRENT_KC = "Current Killcount:";
 	private static final String KILLS_LOGGED = "Kills Logged:";
 	private static final String TOTAL_VALUE = "Total Value:";
+	private static final String TOTAL_VALUE_LATEST = "Total Value (Latest):";
+	private static final String TOTAL_VALUE_HISTORIC = "Total Value (Historic):";
+	private static final String TOTAL_VALUE_HA = "Total Value (HA):";
 	private static final String TOTAL_KILLS = "Total Kills:";
 
 	private final LootLog lootLog;
@@ -185,9 +188,7 @@ class LootPanel extends JPanel
 
 		if (totalValue > 0)
 		{
-			totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
-			totalValuePanel.setVisible(true);
-			totalValuePanel.setToolTipText(buildTotalValueTooltip());
+			updateTotalValuePanel(totalValue);
 			killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
 		}
 
@@ -305,9 +306,7 @@ class LootPanel extends JPanel
 
 		// Update Total Value
 		final long totalValue = lootLog.getLootValue();
-		totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
-		totalValuePanel.setVisible(totalValue > 0);
-		totalValuePanel.setToolTipText(buildTotalValueTooltip());
+		updateTotalValuePanel(totalValue);
 
 		// Update Kills Logged
 		int killsLogged = lootLog.getRecords().size();
@@ -443,6 +442,33 @@ class LootPanel extends JPanel
 			// Default to alphabetical
 			return o1.getName().compareTo(o2.getName());
 		};
+	}
+
+	private void updateTotalValuePanel(long totalValue)
+	{
+		if (totalValue > 0)
+		{
+			totalValuePanel.setVisible(true);
+			totalValuePanel.setToolTipText(buildTotalValueTooltip());
+			switch (config.valueType()) {
+				case HIGH_ALCHEMY:
+					totalValuePanel.updatePanel(TOTAL_VALUE_HA, totalValue);
+					break;
+				case GRAND_EXCHANGE_HISTORIC:
+					totalValuePanel.updatePanel(TOTAL_VALUE_HISTORIC, totalValue);
+					break;
+				case GRAND_EXCHANGE_LATEST:
+					totalValuePanel.updatePanel(TOTAL_VALUE_LATEST, totalValue);
+					break;
+				default:
+					totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
+
+			}
+		}
+		else
+		{
+			totalValuePanel.setVisible(false);
+		}
 	}
 
 	private String buildTotalValueTooltip() {

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -382,7 +382,7 @@ class LootPanel extends JPanel
 			{
 				case ITEM_ID:
 					return o1.getId() - o2.getId();
-				case INDIVIDUAL_VALUE:
+				case PRICE:
 					long p1 = o1.getPriceByType(valueType);
 					long p2 = o2.getPriceByType(valueType);
 
@@ -391,7 +391,7 @@ class LootPanel extends JPanel
 						return p1 > p2 ? -1 : 1;
 					}
 					break;
-				case TOTAL_VALUE:
+				case VALUE:
 					long v1 = o1.getTotalByType(valueType);
 					long v2 = o2.getTotalByType(valueType);
 

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -413,33 +413,6 @@ class LootPanel extends JPanel
 		};
 	}
 
-	private void updateTotalValuePanel(long totalValue)
-	{
-		if (totalValue > 0)
-		{
-			totalValuePanel.setVisible(true);
-			totalValuePanel.setToolTipText(buildTotalValueTooltip());
-			switch (config.valueType()) {
-				case HIGH_ALCHEMY:
-					totalValuePanel.updatePanel(TOTAL_VALUE_HA, totalValue);
-					break;
-				case GRAND_EXCHANGE_HISTORIC:
-					totalValuePanel.updatePanel(TOTAL_VALUE_HISTORIC, totalValue);
-					break;
-				case GRAND_EXCHANGE_LATEST:
-					totalValuePanel.updatePanel(TOTAL_VALUE_LATEST, totalValue);
-					break;
-				default:
-					totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
-
-			}
-		}
-		else
-		{
-			totalValuePanel.setVisible(false);
-		}
-	}
-
 	private void updatePanels(long totalValue, int killsLogged, int currentKillcount, boolean isCurrentSessionLog)
 	{
 		if (totalValue > 0)

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -322,6 +322,9 @@ class LootPanel extends JPanel
 		final String killsLoggedText = lootLog.getName().equalsIgnoreCase(LootLoggerPlugin.SESSION_NAME) ? TOTAL_KILLS : KILLS_LOGGED;
 		killsLoggedPanel.updatePanel(killsLoggedText, killsLogged);
 		killsLoggedPanel.setVisible(killsLogged > 0);
+		if (totalValue > 0) {
+			killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
+		}
 	}
 
 	void playback()

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -187,6 +187,7 @@ class LootPanel extends JPanel
 		{
 			totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
 			totalValuePanel.setVisible(true);
+			totalValuePanel.setToolTipText(buildTotalValueTooltip());
 			killsLoggedPanel.setToolTipText(QuantityFormatter.formatNumber(totalValue / killsLogged) + " gp per kill");
 		}
 
@@ -303,9 +304,10 @@ class LootPanel extends JPanel
 		}
 
 		// Update Total Value
-		final long totalValue = lootLog.getLootValue(config.includeMinions());
+		final long totalValue = lootLog.getLootValue();
 		totalValuePanel.updatePanel(TOTAL_VALUE, totalValue);
 		totalValuePanel.setVisible(totalValue > 0);
+		totalValuePanel.setToolTipText(buildTotalValueTooltip());
 
 		// Update Kills Logged
 		int killsLogged = lootLog.getRecords().size();
@@ -438,5 +440,15 @@ class LootPanel extends JPanel
 			// Default to alphabetical
 			return o1.getName().compareTo(o2.getName());
 		};
+	}
+
+	private String buildTotalValueTooltip() {
+		final long latestTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE_LATEST);
+		final long historicTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
+		final long haTotal = lootLog.getLootValue(ItemValueTypes.HIGH_ALCHEMY);
+
+		return "<html>" + "Total (Latest): " + QuantityFormatter.quantityToStackSize(latestTotal)
+			+ "<br/>Total (Historic): " + QuantityFormatter.quantityToStackSize(historicTotal)
+			+ "<br/>Total (HA): " + QuantityFormatter.quantityToStackSize(haTotal) + "</html>";
 	}
 }

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -409,7 +409,7 @@ class LootPanel extends JPanel
 			{
 				case ITEM_ID:
 					return o1.getId() - o2.getId();
-				case PRICE:
+				case INDIVIDUAL_VALUE:
 					long p1 = o1.getPriceByType(valueType);
 					long p2 = o2.getPriceByType(valueType);
 
@@ -418,7 +418,7 @@ class LootPanel extends JPanel
 						return p1 > p2 ? -1 : 1;
 					}
 					break;
-				case VALUE:
+				case TOTAL_VALUE:
 					long v1 = o1.getTotalByType(valueType);
 					long v2 = o2.getTotalByType(valueType);
 

--- a/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
+++ b/src/main/java/thestonedturtle/lootlogger/ui/LootPanel.java
@@ -60,7 +60,7 @@ class LootPanel extends JPanel
 	private static final String KILLS_LOGGED = "Kills Logged:";
 	private static final String TOTAL_VALUE = "Total Value:";
 	private static final String TOTAL_VALUE_LATEST = "Total Value (Latest):";
-	private static final String TOTAL_VALUE_HISTORIC = "Total Value (Historic):";
+	private static final String TOTAL_VALUE_AVERAGED = "Total Value (Averaged):";
 	private static final String TOTAL_VALUE_HA = "Total Value (HA):";
 	private static final String TOTAL_KILLS = "Total Kills:";
 
@@ -423,10 +423,10 @@ class LootPanel extends JPanel
 				case HIGH_ALCHEMY:
 					totalValuePanel.updatePanel(TOTAL_VALUE_HA, totalValue);
 					break;
-				case GRAND_EXCHANGE_HISTORIC:
-					totalValuePanel.updatePanel(TOTAL_VALUE_HISTORIC, totalValue);
+				case GRAND_EXCHANGE_AVERAGED:
+					totalValuePanel.updatePanel(TOTAL_VALUE_AVERAGED, totalValue);
 					break;
-				case GRAND_EXCHANGE_LATEST:
+				case GRAND_EXCHANGE:
 					totalValuePanel.updatePanel(TOTAL_VALUE_LATEST, totalValue);
 					break;
 				default:
@@ -465,12 +465,12 @@ class LootPanel extends JPanel
 	}
 
 	private String buildTotalValueTooltip() {
-		final long latestTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE_LATEST);
-		final long historicTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE_HISTORIC);
+		final long latestTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE);
+		final long averagedTotal = lootLog.getLootValue(ItemValueTypes.GRAND_EXCHANGE_AVERAGED);
 		final long haTotal = lootLog.getLootValue(ItemValueTypes.HIGH_ALCHEMY);
 
 		return "<html>" + "Total (Latest): " + QuantityFormatter.quantityToStackSize(latestTotal)
-			+ "<br/>Total (Historic): " + QuantityFormatter.quantityToStackSize(historicTotal)
+			+ "<br/>Total (Averaged): " + QuantityFormatter.quantityToStackSize(averagedTotal)
 			+ "<br/>Total (HA): " + QuantityFormatter.quantityToStackSize(haTotal) + "</html>";
 	}
 }


### PR DESCRIPTION
See #75 

Changes:
- Adds historic price summation mode, which sums up the prices at time of drop for a given item rather than assuming all items to be valued at the latest dropped price.
- Renames Value and Price sort modes to be more intuitive.
- Removes an unneeded null check in the LootLog constructor, invalid map keys return an empty collection rather than null. There's probably a bunch more of these.
- Individual item price is the historic dropped average in historic mode.
- Fixes #87 

Todo:
- ~~Single price should be average in historic mode? Feels weird having the single price always be latest even when using historic.~~
- ~~Add some UI indication to the loot panel itself as to which price mode is being used. Probably a `(HA/Latest/Historic)` in the `Total Value` panel.~~
- ~~Add hover tooltip to the `Total Value` panel showing all three price mode totals.~~